### PR TITLE
Adds Pass definition constructor clases.

### DIFF
--- a/config/passgenerator.php
+++ b/config/passgenerator.php
@@ -4,4 +4,8 @@ return [
     'certificate_store_path'        => env('CERTIFICATE_PATH', ''), // The path to the certificate store (a valid  PKCS#12 file)
     'certificate_store_password'    => env('CERTIFICATE_PASS', ''), // The password to unlo
     'wwdr_certificate_path'         => env('WWDR_CERTIFICATE', ''), // Get from here https://www.apple.com/certificateauthority/ and export to PEM
+
+    'pass_type_identifier'          => env('PASS_TYPE_IDENTIFIER', ''),
+    'organization_name'             => env('ORGANIZATION_NAME', ''),
+    'team_identifier'               => env('TEAM_IDENTIFIER', ''),
 ];

--- a/src/Definitions/AbstractDefinition.php
+++ b/src/Definitions/AbstractDefinition.php
@@ -1,0 +1,68 @@
+<?php
+namespace Thenextweb\Definitions;
+
+use Illuminate\Support\Contracts\ArrayableInterface as Arrayable;
+use Illuminate\Support\Contracts\Arr;
+
+abstract class AbstractDefinition implements Arrayable, DefinitionInterface
+{
+    protected $pass = [];
+
+    protected $formatVersion = 1;
+
+    public function __construct()
+    {
+        $this->pass['formatVersion'] = $this->formatVersion;
+    }
+
+
+
+    /**
+     * @param $name
+     * @param $value
+     */
+    public function __set($name, $value)
+    {
+        $this->pass[$name] = $value;
+    }
+
+    /**
+     * @param $name
+     * @return null
+     */
+    public function __get($name)
+    {
+        if (array_key_exists($name, $this->pass)) {
+            return $name;
+        }
+
+        return null;
+    }
+
+    public function __call($name, $args)
+    {
+        $matches = [];
+        if (preg_match('/set([a-z].*)/ig', $name, $matches) && isset($args[0])) {
+            $prop = lcfirst($matches[1]);
+            $this->{$prop} = $args[0];
+
+            return $this;
+        }
+
+        $matches = [];
+        if (preg_match('/get([a-z].*)/ig', $name, $matches)) {
+            $prop = lcfirst($matches[1]);
+            return array_key_exists($prop, $this->pass) ? $this->pass[$prop] : null;
+        }
+
+        throw new \BadMethodCallException();
+    }
+
+    /**
+     * Returns an array representation of the definition compatible with PassKit Package Format
+     */
+    public function toArray()
+    {
+
+    }
+}

--- a/src/Definitions/AbstractDefinition.php
+++ b/src/Definitions/AbstractDefinition.php
@@ -1,68 +1,618 @@
 <?php
 namespace Thenextweb\Definitions;
 
-use Illuminate\Support\Contracts\ArrayableInterface as Arrayable;
-use Illuminate\Support\Contracts\Arr;
+use Carbon\Carbon;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Fluent;
+use Illuminate\Validation\Factory as Validator;
+use Illuminate\Validation\ValidationException;
+use Thenextweb\Definitions\Dictionary\Beacon;
+use Thenextweb\Definitions\Dictionary\Field;
+use Thenextweb\Definitions\Dictionary\Location;
+use Thenextweb\Definitions\Dictionary\Barcode;
+use Thenextweb\Definitions\Dictionary\Nfc;
 
-abstract class AbstractDefinition implements Arrayable, DefinitionInterface
+abstract class AbstractDefinition extends Fluent implements DefinitionInterface
 {
+    const TRANSIT_TYPE_AIR = 'PKTransitTypeAir';
+    const TRANSIT_TYPE_BOAT = 'PKTransitTypeBoat';
+    const TRANSIT_TYPE_BUS = 'PKTransitTypeBus';
+    const TRANSIT_TYPE_GENERIC = 'PKTransitTypeGeneric';
+    const TRANSIT_TYPE_TRAIN = 'PKTransitTypeTrain';
+
     protected $pass = [];
 
     protected $formatVersion = 1;
 
-    public function __construct()
+    /**
+     * @var Validator
+     */
+    protected $validator;
+
+    public function __construct($attributes = [])
     {
-        $this->pass['formatVersion'] = $this->formatVersion;
+        parent::__construct($attributes);
+
+        $this->validator = app('validator');
+
+        $this->attributes['formatVersion'] = $this->formatVersion;
+
+        $this->attributes['passTypeIdentifier'] = config('passbook.pass_type_identifier', '');
+        $this->attributes['organizationName']   = config('passbook.organization_name', '');
+        $this->attributes['teamIdentifier']     = config('passbook.team_identifier', '');
     }
 
+    public function setDescription($description)
+    {
+        $this->attributes['description'] = $description;
 
+        return $this;
+    }
+
+    public function setOrganizationName($organizationName)
+    {
+        $this->attributes['organizationName'] =$organizationName;
+
+        return $this;
+    }
+
+    public function setPassTypeIdentifier($passTypeIdentifier)
+    {
+        $this->attributes['passTypeIdentifier'] = $passTypeIdentifier;
+
+        return $this;
+    }
+
+    public function setSerialNumber($serialNumber)
+    {
+        $this->attributes['serialNumber'] = $serialNumber;
+
+        return $this;
+    }
+
+    public function setTeamIdentifier($teamIdentifier)
+    {
+        $this->attributes['teamIdentifier'] = $teamIdentifier;
+
+        return $this;
+    }
+
+    public function setAppLaunchURL($appLaunchURL, $associatedStoreIdentifier)
+    {
+        $this->attributes['appLaunchURL'] = $appLaunchURL;
+        $this->setAssociatedStoreIdentifier($associatedStoreIdentifier);
+
+        return $this;
+    }
+
+    public function setAssociatedStoreIdentifier($associatedStoreIdentifier)
+    {
+        $this->attributes['associatedStoreIdentifiers'] = is_array($associatedStoreIdentifier)
+            ? $associatedStoreIdentifier
+            : array($associatedStoreIdentifier);
+
+        return $this;
+    }
+
+    public function setUserInfo(array $userInfo)
+    {
+        $this->attributes['userInfo'] = $userInfo;
+
+        return $this;
+    }
+
+    public function setExpirationDate(Carbon $expirationDate)
+    {
+        $this->attributes['expirationDate'] = $expirationDate;
+
+        return $this;
+    }
+
+    public function setVoided(bool $flag)
+    {
+        $this->attributes['voided'] = $flag;
+
+        return $this;
+    }
+
+    public function setBeacons($beacons)
+    {
+        if ($beacons instanceof Collection) {
+            $this->attributes['beacons'] = $beacons;
+        } elseif ($beacons instanceof Beacon) {
+            $this->attributes['beacons'] = collect([$beacons]);
+        } else {
+            throw new \BadMethodCallException('Argument for setBeacons must be a Beacon object or a collection of Beacon objects');
+        }
+    }
+
+    public function addBeacon(Beacon $beacon)
+    {
+        if (!array_key_exists('beacons', $this->attributes)) {
+            $this->attributes['beacons'] = collect();
+        }
+
+        $this->attributes['beacons']->push($beacon);
+
+        return $this;
+    }
+
+    public function setLocations($locations)
+    {
+        if ($locations instanceof Collection) {
+            $this->attributes['locations'] = $locations;
+        } elseif ($locations instanceof Location) {
+            $this->attributes['locations'] = collect([$locations]);
+        } else {
+            throw new \BadMethodCallException('Argument for setLocations must be a Location object or a collection of Location objects');
+        }
+    }
+
+    public function addLocation(Location $location)
+    {
+        if (!array_key_exists('locations', $this->attributes)) {
+            $this->attributes['locations'] = collect();
+        }
+
+        $this->attributes['locations']->push($location);
+
+        return $this;
+    }
+
+    public function setMaxDistance($maxDistance)
+    {
+        $this->attributes['maxDistance'] = $maxDistance;
+
+        return $this;
+    }
+
+    public function setRelevantDate(Carbon $relevantDate)
+    {
+        $this->attributes['relevantDate'] = $relevantDate;
+
+        return $this;
+    }
 
     /**
-     * @param $name
-     * @param $value
+     * For iOS 8 and earlier
+     *
+     * @param Barcode $barcode
+     * @deprecated Use addBarcode instead for iOS 9 and later
      */
-    public function __set($name, $value)
+    public function setBarcode(Barcode $barcode)
     {
-        $this->pass[$name] = $value;
+        $this->attributes['barcode'] = $barcode;
+    }
+
+    public function setBarcodes($barcodes)
+    {
+        if ($barcodes instanceof Collection) {
+            $this->attributes['barcodes'] = $barcodes;
+        } elseif ($barcodes instanceof Barcode) {
+            $this->attributes['barcodes'] = collect([$barcodes]);
+        } else {
+            throw new \BadMethodCallException('Argument for setBarcodes must be a Barcode object or a collection of Barcode objects');
+        }
+    }
+
+    public function addBarcode(Barcode $barcode)
+    {
+        if (!array_key_exists('barcodes', $this->attributes)) {
+            $this->attributes['barcodes'] = collect();
+        }
+
+        $this->attributes['barcodes']->push($barcode);
+
+        return $this;
+    }
+
+    public function setBackgroundColor($color)
+    {
+        $this->attributes['backgroundColor'] = $color;
+
+        return $this;
+    }
+
+    public function setForegroundColor($foregroundColor)
+    {
+        $this->attributes['foregroundColor'] = $foregroundColor;
+
+        return $this;
     }
 
     /**
-     * @param $name
-     * @return null
+     * Valid for Event Tickets and Boarding Passes ONLY
+     *
+     * @param $groupingIdentifier
+     * @return $this
      */
-    public function __get($name)
+    public function setGroupingIdentifier($groupingIdentifier)
     {
-        if (array_key_exists($name, $this->pass)) {
-            return $name;
-        }
+        $this->attributes['groupingIdentifier'] = $groupingIdentifier;
 
-        return null;
+        return $this;
     }
 
-    public function __call($name, $args)
+    public function setLabelColor($labelColor)
     {
-        $matches = [];
-        if (preg_match('/set([a-z].*)/ig', $name, $matches) && isset($args[0])) {
-            $prop = lcfirst($matches[1]);
-            $this->{$prop} = $args[0];
+        $this->attributes['labelColor'] = $labelColor;
 
-            return $this;
-        }
-
-        $matches = [];
-        if (preg_match('/get([a-z].*)/ig', $name, $matches)) {
-            $prop = lcfirst($matches[1]);
-            return array_key_exists($prop, $this->pass) ? $this->pass[$prop] : null;
-        }
-
-        throw new \BadMethodCallException();
+        return $this;
     }
 
+    public function setLogoText($logoText)
+    {
+        $this->attributes['logoText'] = $logoText;
+
+        return $this;
+    }
+
+    public function setSuppressStripShine(bool $flag)
+    {
+        $this->attributes['suppressStripShine'] = $flag;
+
+        return $this;
+    }
+
+    public function setWebService($webServiceURL, $authenticationToken)
+    {
+        $this->attributes['authenticationToken'] = $authenticationToken;
+        $this->attributes['webServiceURL'] = $webServiceURL;
+
+        return $this;
+    }
+
+    public function setNfc(Nfc $nfc)
+    {
+        $this->attributes['nfc'] = $nfc;
+
+        return $this;
+    }
+
+    /* ######### */
+    /* AUXILIARY FIELDS */
+
+    /**
+     * @param Field $field
+     * @return $this
+     */
+    public function appendAuxiliaryField(Field $field)
+    {
+        $this->getStructure('auxiliaryFields')->push($field);
+
+        return $this;
+    }
+
+    public function prependAuxiliaryField(Field $field)
+    {
+        return $this->getStructure('auxiliaryFields')->prepend($field);
+    }
+
+    public function addAuxiliaryField(Field $field)
+    {
+        return $this->appendAuxiliaryField($field);
+    }
+
+    public function getAuxiliaryFields()
+    {
+        return $this->getStructure('auxiliaryFields');
+    }
+
+    /* ######### */
+    /* AUXILIARY FIELDS */
+
+    /**
+     * @param Field $field
+     * @return $this
+     */
+    public function appendBackField(Field $field)
+    {
+        $this->getStructure('backFields')->push($field);
+
+        return $this;
+    }
+
+    public function prependBackField(Field $field)
+    {
+        return $this->getStructure('backFields')->prepend($field);
+    }
+
+    public function addBackField(Field $field)
+    {
+        $this->appendBackField($field);
+
+        return $this;
+    }
+
+    public function getBackFields()
+    {
+        return $this->getStructure('backFields');
+    }
+
+    /* ############### */
+    /* HEADER FIELDS */
+
+    public function appendHeaderField(Field $field)
+    {
+        $this->getStructure('headerFields')->push($field);
+
+        return $this;
+    }
+
+    public function prependHeaderField(Field $field)
+    {
+        return $this->getStructure('headerFields')->prepend($field);
+    }
+
+    public function addHeaderField(Field $field)
+    {
+        $this->appendHeaderField($field);
+
+        return $this;
+    }
+
+    public function getHeaderFields()
+    {
+        return $this->getStructure('headerFields');
+    }
+
+    /* ############### */
+    /* PRIMARY FIELDS */
+
+    public function appendPrimaryField(Field $field)
+    {
+        $this->getStructure('primaryFields')->push($field);
+
+        return $this;
+    }
+
+    public function prependPrimaryField(Field $field)
+    {
+        return $this->getStructure('primaryFields')->prepend($field);
+    }
+
+    public function addPrimaryField(Field $field)
+    {
+        $this->appendPrimaryField($field);
+
+        return $this;
+    }
+
+    public function getPrimaryFields()
+    {
+        return $this->getStructure('primaryFields');
+    }
+
+    /* ############### */
+    /* SECONDARY FIELDS */
+
+    public function appendSecondaryField(Field $field)
+    {
+        $this->getStructure('secondaryFields')->push($field);
+
+        return $this;
+    }
+
+    public function prependSecondaryField(Field $field)
+    {
+        return $this->getStructure('secondaryFields')->prepend($field);
+    }
+
+    public function addSecondaryField(Field $field)
+    {
+        $this->appendSecondaryField($field);
+
+        return $this;
+    }
+
+    public function getSecondaryFields()
+    {
+        return $this->getStructure('secondaryFields');
+    }
+
+
+    public function setTransitType($transitType)
+    {
+        $this->attributes['transitType'] = $transitType;
+
+        return $this;
+    }
+
+    /**
+     * @param $structure
+     * @return mixed
+     */
+    protected function getStructure($structure)
+    {
+        if (!array_key_exists('structure', $this->attributes)) {
+            $this->attributes['structure'] = [];
+        }
+
+        if (!array_key_exists($structure, $this->attributes['structure'])) {
+            $this->attributes['structure'][$structure] = collect();
+        }
+
+        return $this->attributes['structure'][$structure];
+    }
+
+    public function getPassDefinition()
+    {
+        $array = $this->toArray();
+
+        $this->validate($array);
+
+        return $array;
+    }
+    
     /**
      * Returns an array representation of the definition compatible with PassKit Package Format
      */
     public function toArray()
     {
+        $data = array_map(function ($value) {
+            return $value instanceof Arrayable ? $value->toArray() : $value;
+        }, $this->attributes);
 
+        if (array_key_exists('userInfo', $data) && is_array($data['userInfo'])) {
+            $data['userInfo'] = with(new Fluent($data['userInfo']))->toJson();
+        }
+
+        if (array_key_exists('expirationDate', $data) && $data['expirationDate'] instanceof Carbon) {
+            $data['expirationDate'] = $data['expirationDate']->format(DATE_W3C);
+        }
+
+        if (array_key_exists('relevantDate', $data) && $data['relevantDate'] instanceof Carbon) {
+            $data['relevantDate'] = $data['relevantDate']->format(DATE_W3C);
+        }
+        
+        if (array_key_exists('structure', $data)) {
+            $structure = $data['structure'];
+            unset($data['structure']);
+
+
+            foreach ($structure as $key => $value) {
+                if (!$value instanceof Collection) {
+                    continue;
+                }
+
+                $structure[$key] = $value->toArray();
+            }
+
+            $data[$this->style] = $structure;
+        }
+
+        return $data;
+    }
+
+    protected function validate($data)
+    {
+        try {
+            $this->validator->make($data, $this->rules())->validate();
+        } catch (ValidationException $e) {
+            dd($e->validator->getMessageBag()->toArray());
+        }
+    }
+
+    public function rules()
+    {
+        return [
+            'description' => 'required',
+            'formatVersion' => 'required',
+            'organizationName' => 'required',
+            'passTypeIdentifier' => 'required',
+            'serialNumber' => 'required',
+            'teamIdentifier' => 'required',
+
+            //'appLaunchURL'
+            'associatedStoreIdentifiers' => 'required_with:appLaunchURL',
+
+            //'userInfo',
+
+            //'expirationDate,
+            //'voided',
+
+            'beacons' => 'sometimes',
+            //'beacons.*.major',
+            //'beacons.*.minor',
+            'beacons.*.proximityUUID' => 'required',
+            //'beacons.*.relevantText'
+
+            'locations' => 'sometimes',
+            //'locations.*.altitude',
+            'locations.*.latitude' => 'required',
+            'locations.*.longitude' => 'required',
+            //'locations.*.relevantText',
+
+            //'maxDistance',
+            //'relevantDate',
+
+            'boardingPass' => 'sometimes',
+            'boardingPass.transitType' => 'required_with:boardingPass',
+            'boardingPass.auxiliaryFields.*.key' => 'required',
+            'boardingPass.auxiliaryFields.*.value' => 'required',
+            'boardingPass.backFields.*.key' => 'required',
+            'boardingPass.backFields.*.value' => 'required',
+            'boardingPass.headerFields.*.key' => 'required',
+            'boardingPass.headerFields.*.value' => 'required',
+            'boardingPass.primaryFields.*.key' => 'required',
+            'boardingPass.primaryFields.*.value' => 'required',
+            'boardingPass.secondaryFields.*.key' => 'required',
+            'boardingPass.secondaryFields.*.value' => 'required',
+
+            'coupon' => 'sometimes',
+            'coupon.auxiliaryFields.*.key' => 'required',
+            'coupon.auxiliaryFields.*.value' => 'required',
+            'coupon.backFields.*.key' => 'required',
+            'coupon.backFields.*.value' => 'required',
+            'coupon.headerFields.*.key' => 'required',
+            'coupon.headerFields.*.value' => 'required',
+            'coupon.primaryFields.*.key' => 'required',
+            'coupon.primaryFields.*.value' => 'required',
+            'coupon.secondaryFields.*.key' => 'required',
+            'coupon.secondaryFields.*.value' => 'required',
+
+            'eventTicket' => 'sometimes',
+            'eventTicket.auxiliaryFields.*.key' => 'required',
+            'eventTicket.auxiliaryFields.*.value' => 'required',
+            'eventTicket.backFields.*.key' => 'required',
+            'eventTicket.backFields.*.value' => 'required',
+            'eventTicket.headerFields.*.key' => 'required',
+            'eventTicket.headerFields.*.value' => 'required',
+            'eventTicket.primaryFields.*.key' => 'required',
+            'eventTicket.primaryFields.*.value' => 'required',
+            'eventTicket.secondaryFields.*.key' => 'required',
+            'eventTicket.secondaryFields.*.value' => 'required',
+
+            'generic' => 'sometimes',
+            'generic.auxiliaryFields.*.key' => 'required',
+            'generic.auxiliaryFields.*.value' => 'required',
+            'generic.backFields.*.key' => 'required',
+            'generic.backFields.*.value' => 'required',
+            'generic.headerFields.*.key' => 'required',
+            'generic.headerFields.*.value' => 'required',
+            'generic.primaryFields.*.key' => 'required',
+            'generic.primaryFields.*.value' => 'required',
+            'generic.secondaryFields.*.key' => 'required',
+            'generic.secondaryFields.*.value' => 'required',
+
+            'storeCard' => 'sometimes',
+            'storeCard.auxiliaryFields.*.key' => 'required',
+            'storeCard.auxiliaryFields.*.value' => 'required',
+            'storeCard.backFields.*.key' => 'required',
+            'storeCard.backFields.*.value' => 'required',
+            'storeCard.headerFields.*.key' => 'required',
+            'storeCard.headerFields.*.value' => 'required',
+            'storeCard.primaryFields.*.key' => 'required',
+            'storeCard.primaryFields.*.value' => 'required',
+            'storeCard.secondaryFields.*.key' => 'required',
+            'storeCard.secondaryFields.*.value' => 'required',
+
+            'barcode' => 'sometimes',
+            //'barcode.altText',
+            'barcode.format' => 'required_with:barcode',
+            'barcode.message' => 'require_with:barcode',
+            'barcode.messageEncoding' => 'required_with:barcode',
+
+            'barcodes' => 'sometimes|array',
+            //'barcodes.*.altText',
+            'barcodes.*.format' => 'required',
+            'barcodes.*.message' => 'required',
+            'barcodes.*.messageEncoding' => 'required',
+
+            //'backgroundColor',
+            //'foregroundColor',
+            //'groupingIdentifier',
+            //'labelColor',
+            //'logoText',
+            //'suppressStripShine',
+
+            //'webServiceURL',
+            'authenticationToken' => 'required_with:webServiceURL|min:16',
+
+            'nfc' => 'sometimes',
+            'nfc.message' => 'required_with:nfc',
+            //'nfc.encryptionPublicKey',
+        ];
     }
 }

--- a/src/Definitions/BoardingPass.php
+++ b/src/Definitions/BoardingPass.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Jean Rumeau
+ * Date: 14/09/2017
+ * Time: 10:31
+ */
+
+namespace Thenextweb\Definitions;
+
+
+class BoardingPass extends AbstractDefinition
+{
+    protected $style = 'boardingPass';
+}

--- a/src/Definitions/Coupon.php
+++ b/src/Definitions/Coupon.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Jean Rumeau
+ * Date: 13/09/2017
+ * Time: 22:06
+ */
+
+namespace Thenextweb\Definitions;
+
+
+class Coupon extends AbstractDefinition
+{
+    protected $style = 'coupon';
+}

--- a/src/Definitions/DefinitionInterface.php
+++ b/src/Definitions/DefinitionInterface.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Jean Rumeau
+ * Date: 13/09/2017
+ * Time: 21:30
+ */
+
+namespace Thenextweb\Definitions;
+
+
+interface DefinitionInterface
+{
+
+}

--- a/src/Definitions/DefinitionInterface.php
+++ b/src/Definitions/DefinitionInterface.php
@@ -11,5 +11,8 @@ namespace Thenextweb\Definitions;
 
 interface DefinitionInterface
 {
-
+    /**
+     * @return array
+     */
+    public function getPassDefinition();
 }

--- a/src/Definitions/Dictionary/Barcode.php
+++ b/src/Definitions/Dictionary/Barcode.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Jean Rumeau
+ * Date: 13/09/2017
+ * Time: 23:17
+ */
+
+namespace Thenextweb\Definitions\Dictionary;
+
+
+use Illuminate\Support\Fluent;
+
+class Barcode extends Fluent
+{
+    const FORMAT_QR = 'PKBarcodeFormatQR';
+    const FORMAT_PDF417 = 'PKBarcodeFormatPDF417';
+    const FORMAT_AZTEX = 'PKBarcodeFormatAztec';
+    const FORMAT_CODE128 = 'PKBarcodeFormatCode128';
+
+    /**
+     * Barcode constructor.
+     * @param array|object $message
+     * @param $format
+     * @param string $messageEncoding
+     */
+    public function __construct($message, $format, $messageEncoding = 'iso-8859-1')
+    {
+        $this->attributes['message'] = $message;
+        $this->attributes['format'] = $format;
+        $this->attributes['messageEncoding'] = 'iso-8859-1';
+
+        return $this;
+    }
+
+    /**
+     * @param $altText
+     * @return $this
+     */
+    public function setAltText($altText)
+    {
+        $this->attributes['altText'] = $altText;
+
+        return $this;
+    }
+
+    /**
+     * @param $format
+     * @return $this
+     */
+    public function setFormat($format)
+    {
+        $this->attributes['format'] = $format;
+
+        return $this;
+    }
+
+    /**
+     * @param $message
+     * @return $this
+     */
+    public function setMessage($message)
+    {
+        $this->attributes['message'] = $message;
+
+        return $this;
+    }
+
+    /**
+     * @param $messageEncoding
+     * @return $this
+     */
+    public function setMessageEncoding($messageEncoding)
+    {
+        $this->attributes['messageEncoding'] = $messageEncoding;
+
+        return $this;
+    }
+}

--- a/src/Definitions/Dictionary/Beacon.php
+++ b/src/Definitions/Dictionary/Beacon.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Jean Rumeau
+ * Date: 13/09/2017
+ * Time: 22:24
+ */
+
+namespace Thenextweb\Definitions\Dictionary;
+
+use Illuminate\Support\Fluent;
+
+
+class Beacon extends Fluent
+{
+    /**
+     * @param $major
+     * @return $this
+     */
+    public function setMajor($major)
+    {
+        $this->attributes['major'] = $major;
+
+        return $this;
+    }
+
+    /**
+     * @param $minor
+     * @return $this
+     */
+    public function setMinor($minor)
+    {
+        $this->attributes['minor'] = $minor;
+
+        return $this;
+    }
+
+    /**
+     * @param $proximityUUID
+     * @return $this
+     */
+    public function setProximityUUID($proximityUUID)
+    {
+        $this->attributes['proximityUUID'] = $proximityUUID;
+
+        return $this;
+    }
+
+    /**
+     * @param $relevantText
+     * @return $this
+     */
+    public function setRelevantText($relevantText)
+    {
+        $this->attributes['relevantText'] = $relevantText;
+
+        return $this;
+    }
+}

--- a/src/Definitions/Dictionary/Date.php
+++ b/src/Definitions/Dictionary/Date.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Jean Rumeau
+ * Date: 14/09/2017
+ * Time: 11:46
+ */
+
+namespace Thenextweb\Definitions\Dictionary;
+
+
+use Carbon\Carbon;
+
+class Date extends Field
+{
+    const STYLE_NONE = 'PKDateStyleNone';
+    const STYLE_SHORT = 'PKDateStyleShort';
+    const STYLE_MEDIUM = 'PKDateStyleMedium';
+    const STYLE_LONG = 'PKDateStyleLong';
+    const STYLE_FULL = 'PKDateStyleFull';
+
+    /**
+     * @param $dateStyle
+     * @return $this
+     */
+    public function setDateStyle($dateStyle)
+    {
+        $this->attributes['dateStyle'] = $dateStyle;
+        
+        return $this;
+    }
+
+    /**
+     * @param bool $flag
+     * @return $this
+     */
+    public function setIgnoresTimeZone(bool $flag)
+    {
+        $this->attributes['ignoresTimeZone'] = $flag;
+
+        return $this;
+    }
+
+    /**
+     * @param bool $flag
+     * @return $this
+     */
+    public function setIsRelative(bool $flag)
+    {
+        $this->attributes['isRelative'] = $flag;
+
+        return $this;
+    }
+
+    /**
+     * @param $timeStyle
+     * @return $this
+     */
+    public function setTimeStyle($timeStyle)
+    {
+        $this->attributes['timeStyle'] = $timeStyle;
+
+        return $this;
+    }
+
+    /**
+     *
+     */
+    public function toArray()
+    {
+        $data = [];
+        foreach ($this->attributes as $key => $value) {
+            if ($value instanceof Carbon) {
+                $data[$key] = $value->format(DATE_ISO8601);
+            } else {
+                $data[$key] = $value;
+            }
+        }
+
+        return $data;
+    }
+}

--- a/src/Definitions/Dictionary/Field.php
+++ b/src/Definitions/Dictionary/Field.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Jean Rumeau
+ * Date: 14/09/2017
+ * Time: 9:36
+ */
+
+namespace Thenextweb\Definitions\Dictionary;
+
+
+use Illuminate\Support\Fluent;
+
+class Field extends Fluent
+{
+    const DETECTOR_TYPE_PHONE = 'PKDataDetectorTypePhoneNumber';
+    const DETECTOR_TYPE_LINK = 'PKDataDetectorTypeLink';
+    const DETECTOR_TYPE_ADDRESS = 'PKDataDetectorTypeAddress';
+    const DETECTOR_TYPE_CALENDAR_EVENT = 'PKDataDetectorTypeCalendarEvent';
+
+    const TEXT_ALIGNMENT_LEFT = 'PKTextAlignmentLeft';
+    const TEXT_ALIGNMENT_CENTER = 'PKTextAlignmentCenter';
+    const TEXT_ALIGNMENT_RIGHT = 'PKTextAlignmentRight';
+    const TEXT_ALIGNMENT_NATURAL = 'PKTextAlignmentNatural';
+
+    /**
+     * Field constructor.
+     * @param $key
+     * @param $value
+     * @param $attributes
+     */
+    public function __construct($key, $value, $attributes = [])
+    {
+        parent::__construct($attributes);
+
+        $this->attributes['key'] = $key;
+        $this->attributes['value'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param $attributedValue
+     * @return $this
+     */
+    public function setAttributedValue($attributedValue)
+    {
+        $this->attributes['attributedValue'] = $attributedValue;
+
+        return $this;
+    }
+
+    /**
+     * @param $changeMessage
+     * @return $this
+     */
+    public function setChangeMessage($changeMessage)
+    {
+        $this->attributes['changeMessage'] = $changeMessage;
+
+        return $this;
+    }
+
+    /**
+     * @param $dataDetectorTypes
+     * @return $this
+     */
+    public function setDataDetectorTypes($dataDetectorTypes)
+    {
+        $this->attributes['dataDetectorTypes'] = $dataDetectorTypes;
+
+        return $this;
+    }
+
+    /**
+     * @param $key
+     * @return $this
+     */
+    public function setKey($key)
+    {
+        $this->attributes['key'] = $key;
+
+        return $this;
+    }
+
+    /**
+     * @param $label
+     * @return $this
+     */
+    public function setLabel($label)
+    {
+        $this->attributes['label'] = $label;
+
+        return $this;
+    }
+
+    /**
+     * @param $textAlignment
+     * @return $this
+     */
+    public function setTextAlignment($textAlignment)
+    {
+        $this->attributes['textAlignment'] = $textAlignment;
+
+        return $this;
+    }
+
+    /**
+     * @param $value
+     * @return $this
+     */
+    public function setValue($value)
+    {
+        $this->attributes['value'] = $value;
+
+        return $this;
+    }
+}

--- a/src/Definitions/Dictionary/Location.php
+++ b/src/Definitions/Dictionary/Location.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Jean Rumeau
+ * Date: 13/09/2017
+ * Time: 23:01
+ */
+
+namespace Thenextweb\Definitions\Dictionary;
+
+
+use Illuminate\Support\Fluent;
+
+class Location extends Fluent
+{
+    public function setAltitude($altitude)
+    {
+        $this->attributes['altitude'] = $altitude;
+
+        return $this;
+    }
+
+    public function setLatitude($latitude)
+    {
+        $this->attributes['latitude'] = $latitude;
+
+        return $this;
+    }
+
+    public function setLongitude($longitude)
+    {
+        $this->attributes['longitude'] = $longitude;
+
+        return $this;
+    }
+
+    public function setRelevantText($relevantText)
+    {
+        $this->attributes['relevantText'] = $relevantText;
+
+        return $this;
+    }
+}

--- a/src/Definitions/Dictionary/Nfc.php
+++ b/src/Definitions/Dictionary/Nfc.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Jean Rumeau
+ * Date: 13/09/2017
+ * Time: 23:29
+ */
+
+namespace Thenextweb\Definitions\Dictionary;
+
+
+use Illuminate\Support\Fluent;
+
+class Nfc extends Fluent
+{
+    public function __construct($message, $encryptionPublicKey = '')
+    {
+        $this->attributes['message'] = $message;
+        if (!empty($encryptionPublicKey)) {
+            $this->attributes['encryptionPublicKey'] = $encryptionPublicKey;
+        }
+
+        return $this;
+    }
+
+    public function setMessage($message)
+    {
+        $this->attributes['message'] = $message;
+
+        return $this;
+    }
+
+    public function setEncryptionPublicKey($encryptionPublicKey)
+    {
+        $this->attributes['encryptionPublicKey'] = $encryptionPublicKey;
+
+        return $this;
+    }
+}

--- a/src/Definitions/Dictionary/Number.php
+++ b/src/Definitions/Dictionary/Number.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Jean Rumeau
+ * Date: 14/09/2017
+ * Time: 11:46
+ */
+
+namespace Thenextweb\Definitions\Dictionary;
+
+
+class Number extends Field
+{
+    const STYLE_DECIMAL = 'PKNumberStyleDecimal';
+    const STYLE_PERCENT = 'PKNumberStylePercent';
+    const STYLE_SCIENTIFIC = 'PKNumberStyleScientific';
+    const STYLE_SPELLOUT = 'PKNumberStyleSpellOut';
+
+    /**
+     * @param $currencyCode
+     * @return $this
+     */
+    public function setCurrencyCode($currencyCode)
+    {
+        $this->attributes['currencyCode'] = $currencyCode;
+
+        return $this;
+    }
+
+    /**
+     * @param $numberStyle
+     * @return $this
+     */
+    public function setNumberStyle($numberStyle)
+    {
+        $this->attributes['numberStyle'] = $numberStyle;
+
+        return $this;
+    }
+}

--- a/src/Definitions/EventTicket.php
+++ b/src/Definitions/EventTicket.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Jean Rumeau
+ * Date: 14/09/2017
+ * Time: 10:31
+ */
+
+namespace Thenextweb\Definitions;
+
+
+class EventTicket extends AbstractDefinition
+{
+    protected $style = 'eventTicket';
+}

--- a/src/Definitions/Generic.php
+++ b/src/Definitions/Generic.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Jean Rumeau
+ * Date: 14/09/2017
+ * Time: 10:31
+ */
+
+namespace Thenextweb\Definitions;
+
+
+class Generic extends AbstractDefinition
+{
+    protected $style = 'generic';
+}

--- a/src/Definitions/StoreCard.php
+++ b/src/Definitions/StoreCard.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Jean Rumeau
+ * Date: 14/09/2017
+ * Time: 10:31
+ */
+
+namespace Thenextweb\Definitions;
+
+
+class StoreCard extends AbstractDefinition
+{
+    protected $style = 'storeCard';
+}

--- a/src/PassGenerator.php
+++ b/src/PassGenerator.php
@@ -5,6 +5,7 @@ namespace Thenextweb;
 use Illuminate\Support\Facades\Storage;
 use InvalidArgumentException;
 use RuntimeException;
+use Thenextweb\Definitions\DefinitionInterface;
 use ZipArchive;
 
 class PassGenerator
@@ -196,6 +197,10 @@ class PassGenerator
      */
     public function setPassDefinition($definition)
     {
+        if ($definition instanceof DefinitionInterface) {
+            $definition = $definition->getPassDefinition();
+        }
+
         if (!is_array($definition)) {
             throw new InvalidArgumentException('An invalid Pass definition was provided.');
         }


### PR DESCRIPTION
This PR adds some clases to generate a pass definition using an object instead of an array.

This allows to easily programatically modify parts of the definition using object reference

IE:

```php
$coupon = Thenextweb\Definitions\Coupon();
$coupon->setDescription('Coupon description');
$coupon->setSerialNumber('123456');

$coupon->setUserInfo([
    'email' => 'user@domain.com',
]);
$coupon->setExpirationDate(Carbon::now()->addMonths(6));

$location = new Location();
$location->setLatitude(40.4378698);
$location->setLongitude(-3.819619);
$coupon->addLocation($location);

$coupon->setMaxDistance(50);
$coupon->setRelevantDate(Carbon::now()->addDays(10));

$coupon->addAuxiliaryField(new Field('key', 'value'));

$coupon->addBackField(new Number('price', 13, [
    'currencyCode' => 'EUR',
    'numberStyle' => Number::STYLE_DECIMAL
]));

$coupon->addPrimaryField(new Date('created_at', Carbon::now(), [
    'dateStyle' => Date::STYLE_FULL,
]));

$barcode = new Barcode('7898466321', Barcode::FORMAT_CODE128);
$coupon->addBarcode($barcode);

$passgenerator->setPassDefinition($coupon);
```