### PR TITLE
Fix date format, uses 'c' as DATE_ISO8601 is not valid ISO-8601 date.

### DIFF
--- a/src/Definitions/Dictionary/Date.php
+++ b/src/Definitions/Dictionary/Date.php
@@ -71,7 +71,7 @@ class Date extends Field
         $data = [];
         foreach ($this->attributes as $key => $value) {
             if ($value instanceof Carbon) {
-                $data[$key] = $value->format(DATE_ISO8601);
+                $data[$key] = $value->format('c');
             } else {
                 $data[$key] = $value;
             }

--- a/src/Definitions/Dictionary/Date.php
+++ b/src/Definitions/Dictionary/Date.php
@@ -71,7 +71,7 @@ class Date extends Field
         $data = [];
         foreach ($this->attributes as $key => $value) {
             if ($value instanceof Carbon) {
-                $data[$key] = $value->format('c');
+                $data[$key] = $value->toW3cString();
             } else {
                 $data[$key] = $value;
             }


### PR DESCRIPTION
I used DATE_ISO8601 for formatting dates, but as this format is not valid ISO-8601, it fails to display on IPhone.

I set it to use 'c' which is valid ISO-8601 format and now is working.

Greetings.