### PR TITLE
Fix: real path pass generation for older Laravel versions

### DIFF
--- a/src/PassGenerator.php
+++ b/src/PassGenerator.php
@@ -148,10 +148,8 @@ class PassGenerator
                 );
             }
         }
-        /** @var \Illuminate\Filesystem\FilesystemAdapter $disk */
-        $disk = Storage::disk('passgenerator');
-        $root = Arr::get($disk->getConfig(), 'root', storage_path());
-        $this->passRealPath = rtrim($root, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $this->passRelativePath;
+
+        $this->passRealPath = Storage::disk('passgenerator')->path($this->passRelativePath);
     }
 
     /**


### PR DESCRIPTION
Hi,

This PR simplifies the way the `realPassPath` is generated.
I believe this piece of legacy code was last updated in [this commit](https://github.com/thenextweb/passgenerator/commit/5a18579cfb46b083709654d343163470a2347244) to be compatible with Laravel 9.
However, that change made it incompatible with any previous versions of Laravel. See #32 

Instead of retrieving the root of the `passgenerator` disk and manually concatenate the `passRelativePath` to it, we now leverage the `path` method to build the path.

This also fixes an issue where `Storage::fake('passgenerator')` would not work.


