### PR TITLE
#fix: Typo corrected on the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Passgenerator is a Laravel7+ package that allows you to easily create passes com
 Only things needed are Laravel 7+ and to have the [PHP Zip extension](http://php.net/manual/en/book.zip.php) installed and enabled.
 
 ## 💾 Installation
-The best and easiest way o install the package is using the [Composer](https://getcomposer.org/) package manager. To do so, run this command in your project root:
+The best and easiest way to install the package is using the [Composer](https://getcomposer.org/) package manager. To do so, run this command in your project root:
 
 ```sh
 composer require thenextweb/passgenerator


### PR DESCRIPTION
Small typo correction in the readme file changed `o` to `to`