### PR TITLE
Fix returning a path

### DIFF
--- a/src/PassGenerator.php
+++ b/src/PassGenerator.php
@@ -310,7 +310,7 @@ class PassGenerator
     public function getPassFilePath(string $passId)
     {
         if (Storage::disk('passgenerator')->exists($passId . '.pkpass')) {
-            return $this->passRealPath . '/../' . $this->passFilename;
+            return Storage::disk('passgenerator')->path($passId . '.pkpass');
         }
 
         return false;


### PR DESCRIPTION
I noticed this function was not using the Pass ID pass when returning the path, and it required passing in the Pass ID as a constructor. It now allows for the following interaction:

```php
$pass = new PassGenerator;
$pass->getPassFilePath($uuid);
```